### PR TITLE
some editorial stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-DNS Security extensions (DNSSEC) are additions to the DNS protocol which provide data integrity and authenticity protections, but do not provide privacy.
+DNS Security Extensions (DNSSEC) are additions to the DNS protocol which provide data integrity and authenticity protections, but do not provide privacy.
 
 
 # Conventions and Definitions
@@ -12,21 +12,21 @@ when, and only when, they appear in all capitals, as shown here.
 
 # Background
 
-Use of DNSSEC requires upgrades to software for authorative servers, resolvers, and optionally clients, in order to benefit from these protections. It also requires that DNS operators actually sign their zones.
+Use of DNSSEC requires upgrades to software for authorative servers, resolvers, and optionally clients, in order to benefit from these protections. It also requires that DNS operators actually sign their zones and secure the corresponding delegations at the parent.
 
-When a given zone is unsigned, those protections to the zone contents are not available.
+When a given zone is unsigned or not securely delegated, those protections to the zone contents are not available.
 
-Any unsigned zone is trivially able to be altered by an on-path attacker.
+Any such insecure zone is trivially able to be altered by an on-path attacker.
 
 An off-path attacker is limited to use of cache poisoning attacks.
 
-However, some class of cache poisoning attacks target unsigned delegation data. These records consist of the necessary NS records, and when necessary, "glue" records for IP address corresponding to these NS records.
+However, some class of cache poisoning attacks target unsigned delegation data. These records consist of the necessary NS records, and when necessary, "glue" records for IP addresses corresponding to these NS records.
 
 The impact to successful cache poisoning of delegation records is that the attacker may substitute their own name servers for the legitimate name server. In other words, the attacker is able to promote itself to being effectively on-path, and trivially modify unsigned domain results.
 
 # Proposed Solutions
 
-There are two delegation record types that require protection against off-path attackers, for unsigned domains.
+There are two kinds of delegation records that require protection against off-path attackers, for unsigned domains.
 
 For protecting NS records used in delegations, there is a new proposal for use of a new DS record. See [@I-D.dickson-dnsop-ds-hack] for details.
 
@@ -37,7 +37,7 @@ The present draft addresses the "glue" records, by recommending methods to make 
 The following practice is RECOMMENDED for unsigned zones:
 
 * Do not use in-bailiwick name server names for unsigned zones.
-* Use out-of-zone names for the name servers for unsigned zones
+* Use out-of-zone names for the name servers of unsigned zones.
 
 Example:
 
@@ -64,12 +64,12 @@ Example:
     ns2.nameserver-signed-zone.example AAAA (IP address)
     ns2.nameserver-signed-zone.example AAAA (IP address)
 
-The following practice is RECOMMENDED (for signed name server name zones, i.e. large operators' zones):
+The following practice is RECOMMENDED (for signed name server name zones):
 
 * For name server name zones (zones containing data for name servers), use dedicated name server names for the zone itself
 * Consider use of another zone for the dedicated name server names, to make the name server name zone itself fully glueless
 * For this additional zone, also consider using a different name server _name_ for its delegation's exclusive use 
-* Decoupling the respective NS names, ensures changes and updates to the zone that uses glue, don't affect any other zones
+* Decoupling the respective NS names ensures that changes and updates to the zone that uses glue don't affect any other zones
 * Depending on parent zone policy (e.g. TLD database policy), renaming or renumbering name servers may affect delegations using them (NS entries)
 * A single zone with non-reused NS names guarantees side effects of this sort are not possible
 * Additional lookups are required on the initial reference to any NS in the main glueless zone
@@ -137,7 +137,7 @@ This guidance is useful in preventing off-path attackers from poisoning DNS cach
 
 However, an on-path attacker is still able to manipulate DNS responses sent over UDP or unencrypted TCP.
 
-Use of an encrypted transport is one potential method of preventing MITM attacks (i.e. DNS over TLS from resolver to authoritative server, aka ADoT), but this is still less secure than use of DNSSEC.
+Use of an encrypted transport is one potential method of preventing MITM attacks (i.e. DNS over TLS from resolver to authoritative server, aka ADoT), but this still does not provide the same security properties as DNSSEC (in particular that the zone contents are authorized by the DNSSEC key holder).
 
 # IANA Considerations
 


### PR DESCRIPTION
Lines 69-76 are unclear to me and very hard to follow, partly because of undefined or vague terminology. Example: "main glueless zone" -- what's main? also, "delegation" (instead of "zone")?

I can imagine that it would help to interweave the arguments with the examples, such as "don't do [suboptimal delegation]", followed by example, then: "better do [correct actual delegation]", followed by example; then repeat with the next delegation (for the nameserver zone) etc.

It also would help if the document clearly stated at the beginning that nothing new is introduced, but that deliberate use is made of the structural properties of customary glue configurations, to prevent vulnerable configurations. (I found myself waiting for some new specification and only realized towards the end that it's not coming.)